### PR TITLE
CI: Minor fixes

### DIFF
--- a/.github/workflows/pnpm-wireit-ci.yml
+++ b/.github/workflows/pnpm-wireit-ci.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          cache: true
 
       # Wireit cache
       - uses: google/wireit@setup-github-actions-caching/v1

--- a/.github/workflows/pnpm-wireit-release.yml
+++ b/.github/workflows/pnpm-wireit-release.yml
@@ -18,11 +18,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 18.x
-          cache: true
 
       # Wireit cache
       - uses: google/wireit@setup-github-actions-caching/v1

--- a/pnpm-wireit/.changeset/config.json
+++ b/pnpm-wireit/.changeset/config.json
@@ -3,5 +3,5 @@
   "changelog": ["@changesets/changelog-github", { "repo": "FormidableLabs/monorepo-infra-experiments" }],
   "access": "public",
   "baseBranch": "main",
-  "linked": [["@formidable/monorepo-tools-pnpm-wireit-dogs-*"]]
+  "fixed": [["*"]]
 }

--- a/pnpm-wireit/.changeset/config.json
+++ b/pnpm-wireit/.changeset/config.json
@@ -3,5 +3,5 @@
   "changelog": ["@changesets/changelog-github", { "repo": "FormidableLabs/monorepo-infra-experiments" }],
   "access": "public",
   "baseBranch": "main",
-  "fixed": [["*"]]
+  "fixed": [["@formidable/monorepo-tools-pnpm-wireit-dogs-*"]]
 }

--- a/pnpm-wireit/README.md
+++ b/pnpm-wireit/README.md
@@ -47,7 +47,7 @@ Here are more details:
 When you would like to add a changeset (which creates a file indicating the type of change), in your branch/PR issue this command:
 
 ```sh
-$ pnpm changeset add
+$ pnpm changeset
 ```
 
 to produce an interactive menu. Navigate the packages with arrow keys and hit `<space>` to select 1+ packages. Hit `<return>` when done. Select semver versions for packages and add appropriate messages. From there, you'll get a summary to approve. After this, you'll see a new uncommitted file in `.changesets` like:
@@ -74,7 +74,7 @@ On the merge of a version packages PR, the changesets GitHub action will publish
 
 For exceptional circumstances, here is a quick guide to manually publishing from a local computer using changesets.
 
-1. Add a changeset with `pnpm changeset add`. Add changeset file, review file, tweak, and commit.
+1. Add a changeset with `pnpm changeset`. Add changeset file, review file, tweak, and commit.
 2. Make a version. Due to our `changesets/changelog-github` package you will need to create a personal token and pass it to the environment.
 
     ```sh

--- a/pnpm-wireit/package.json
+++ b/pnpm-wireit/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/FormidableLabs/monorepo-infra-experiments#readme",
   "scripts": {
     "version": "pnpm changeset version && pnpm install --fix-lockfile",
+    "changeset": "changeset",
     "build": "pnpm -r run build",
     "build:watch": "pnpm --parallel run build --watch",
     "clean": "pnpm --parallel exec nps clean"


### PR DESCRIPTION
- There is no `cache:` option
- Remove reference to matrix when we're not using a matrix. (cc @scottrippey thanks for commenting on this!)
- Switch to `fixed` packages to ensure lockstep bumps.
- Docs improvements for changeset addition.