### PR TITLE
Publish single git tag

### DIFF
--- a/.github/workflows/pnpm-wireit-release.yml
+++ b/.github/workflows/pnpm-wireit-release.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build packages
         run: pnpm run clean && pnpm run build
 
+      - name: Add npm token for publishing
+        run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+
       - name: PR or Publish
         id: changesets
         uses: changesets/action@v1
@@ -57,7 +60,7 @@ jobs:
           # Not needed in normal project. Looks like working-directory is ignored.
           cwd: ./pnpm-wireit
           version: pnpm run version
-          publish: pnpm changeset publish
+          publish: pnpm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/pnpm-wireit/.changeset/six-kings-act.md
+++ b/pnpm-wireit/.changeset/six-kings-act.md
@@ -1,5 +1,0 @@
----
-"@formidable/monorepo-tools-pnpm-wireit-dogs-beau": patch
----
-
-Noop bump for beau

--- a/pnpm-wireit/.changeset/six-kings-act.md
+++ b/pnpm-wireit/.changeset/six-kings-act.md
@@ -1,0 +1,5 @@
+---
+"@formidable/monorepo-tools-pnpm-wireit-dogs-beau": patch
+---
+
+Noop bump for beau

--- a/pnpm-wireit/README.md
+++ b/pnpm-wireit/README.md
@@ -102,13 +102,13 @@ For exceptional circumstances, here is a quick guide to manually publishing from
 
     ```sh
     # Test things out first
-    $ pnpm -r publish --dry-run
+    $ pnpm run publish:dry-run
+    # If your git branch is dirty (and yes, with two `--`s!)
+    $ pnpm run publish:dry-run -- -- --no-git-checks
 
     # The real publish
-    $ pnpm changeset publish --otp=<insert otp code>
+    $ pnpm run publish -- -- --otp=<insert otp code>
     ```
-
-    Note that publishing multiple pacakges via `changeset` to npm with an OTP code can often fail with `429 Too Many Requests` rate limiting error. Take a 5+ minute coffee break, then come back and try again.
 
     Then issue the following to also push git tags:
 

--- a/pnpm-wireit/package-scripts.js
+++ b/pnpm-wireit/package-scripts.js
@@ -6,10 +6,18 @@
  * If you have an actual root task, define it in root `package.json:scripts`.
  */
 
+// For publishing, use the core package's version.
+const coreVersion = require("./packages/core/package.json").version;
+if (!coreVersion) {
+  throw new Error("Unable to read core version");
+}
+
 module.exports = {
   scripts: {
     "build:esm": "babel src --out-dir es --config-file ../../.babelrc.js --copy-files --extensions .tsx,.ts,.jsx,.js",
     "build:cjs": "BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.js --copy-files --extensions .tsx,.ts,.jsx,.js",
-    "clean": "rm -rf es lib"
+    "clean": "rm -rf es lib",
+    "publish:dry-run": `git tag -a v${coreVersion} -m \"Version ${coreVersion}\" && pnpm -r publish --access public`,
+    "publish:dry-run": `echo git tag -a v${coreVersion} -m \"Version ${coreVersion}\" && pnpm -r publish --access public --dry-run`
   }
 };

--- a/pnpm-wireit/package-scripts.js
+++ b/pnpm-wireit/package-scripts.js
@@ -17,7 +17,7 @@ module.exports = {
     "build:esm": "babel src --out-dir es --config-file ../../.babelrc.js --copy-files --extensions .tsx,.ts,.jsx,.js",
     "build:cjs": "BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.js --copy-files --extensions .tsx,.ts,.jsx,.js",
     "clean": "rm -rf es lib",
-    "publish:dry-run": `git tag -a v${coreVersion} -m \"Version ${coreVersion}\" && pnpm -r publish --access public`,
+    "publish": `git tag -a v${coreVersion} -m \"Version ${coreVersion}\" && pnpm -r publish --access public`,
     "publish:dry-run": `echo git tag -a v${coreVersion} -m \"Version ${coreVersion}\" && pnpm -r publish --access public --dry-run`
   }
 };

--- a/pnpm-wireit/package.json
+++ b/pnpm-wireit/package.json
@@ -16,7 +16,8 @@
   "homepage": "https://github.com/FormidableLabs/monorepo-infra-experiments#readme",
   "scripts": {
     "version": "pnpm changeset version && pnpm install --fix-lockfile",
-    "changeset": "changeset",
+    "publish": "nps publish",
+    "publish:dry-run": "nps publish:dry-run",
     "build": "pnpm -r run build",
     "build:watch": "pnpm --parallel run build --watch",
     "clean": "pnpm --parallel exec nps clean"


### PR DESCRIPTION
This changes out changesets publishing scheme to manually use pnpm to publish instead of changesets so we can manually use a single git tag for all packages.

I'm going to merge this and try things out and iterate from there...