### PR TITLE
Publish with a single git tag.

### DIFF
--- a/.github/workflows/pnpm-wireit-release.yml
+++ b/.github/workflows/pnpm-wireit-release.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build packages
         run: pnpm run clean && pnpm run build
 
+      - name: Add npm token for publishing
+        run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+
       - name: PR or Publish
         id: changesets
         uses: changesets/action@v1
@@ -57,7 +60,7 @@ jobs:
           # Not needed in normal project. Looks like working-directory is ignored.
           cwd: ./pnpm-wireit
           version: pnpm run version
-          publish: pnpm changeset publish
+          publish: pnpm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/pnpm-wireit/README.md
+++ b/pnpm-wireit/README.md
@@ -105,7 +105,8 @@ For exceptional circumstances, here is a quick guide to manually publishing from
     $ pnpm -r publish --dry-run
 
     # The real publish
-    $ pnpm changeset publish --otp=<insert otp code>
+    # This first does a single git tag (if not already present), then publishes
+    $ pnpm run publish --otp=<insert otp code>
     ```
 
     Note that publishing multiple pacakges via `changeset` to npm with an OTP code can often fail with `429 Too Many Requests` rate limiting error. Take a 5+ minute coffee break, then come back and try again.

--- a/pnpm-wireit/package-scripts.js
+++ b/pnpm-wireit/package-scripts.js
@@ -1,15 +1,33 @@
 /**
- * We only use `nps` for scripts that we:
+ * We generally use `nps` for scripts that we:
  * 1. define at the root of the monorepo
  * 2. that are meant to execute _within_ a workspace
  *
- * If you have an actual root task, define it in root `package.json:scripts`.
+ * ... or ...
+ *
+ * - That could use a little JS magic that we don't want to write a full
+ *   node script for 😂
+ *
+ * For more cases, if you have an actual root task, define it in root
+ * `package.json:scripts`.
  */
+
+// For publishing, use the core package's version.
+const coreVersion = require("./packages/core/package.json").version;
+if (!coreVersion) {
+  throw new Error("Unable to read core version");
+}
+const coreTag = `v${coreVersion}`;
 
 module.exports = {
   scripts: {
+    // Package tasks.
     "build:esm": "babel src --out-dir es --config-file ../../.babelrc.js --copy-files --extensions .tsx,.ts,.jsx,.js",
     "build:cjs": "BABEL_ENV=commonjs babel src --out-dir lib --config-file ../../.babelrc.js --copy-files --extensions .tsx,.ts,.jsx,.js",
-    "clean": "rm -rf es lib"
+    "clean": "rm -rf es lib",
+
+    // Root tasks.
+    // Try to find an existing tag (from previous attempts, etc.), and if not, create one.
+    "git:tag": `git show-ref ${coreTag} || git tag -a ${coreTag} -m \"Version ${coreVersion}\"`
   }
 };

--- a/pnpm-wireit/package.json
+++ b/pnpm-wireit/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/FormidableLabs/monorepo-infra-experiments#readme",
   "scripts": {
     "version": "pnpm changeset version && pnpm install --fix-lockfile",
+    "publish": "nps git:tag && pnpm changeset publish --no-git-tag",
     "changeset": "changeset",
     "build": "pnpm -r run build",
     "build:watch": "pnpm --parallel run build --watch",


### PR DESCRIPTION
This is a _much_ simpler version of my previous failed attempt at #23 

- Use a single "core" package's version as the git tag version. Since we use changesets `fixed` all should be the same.
- Create a git tag for that version if it doesn't already exist.
- Publish (via `changesets publish`) if not already published. Changesets no longer does git tagging.